### PR TITLE
[AP-345] Add export_events optional param

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This tap:
   - Bookmark: `time`
   - Bookmark query field: `from_date`, `to_date`
 - Transformations: De-nest `properties` to root-level, re-name properties with leading `$...` to `mp_reserved_...`, convert datetimes from project timezone to UTC.
+- Optional parameters
+  - `export_events` to export only certain events
 
 **[engage](https://developer.mixpanel.com/docs/data-export-api#section-engage)**
 - Endpoint: https://mixpanel.com/api/2.0/engage
@@ -123,6 +125,13 @@ More details may be found in the [Mixpanel API Authentication](https://developer
         "user_agent": "tap-mixpanel <api_user_email@your_company.com>"
     }
     ```
+    
+    If you want to export only certain events from the [Raw export API](https://developer.mixpanel.com/reference/export)
+    then add `export_events` option to the `config.json` and list the required event names:
+    
+    ```bash
+   "export_events": ["event_one", "event_two"]
+   ```
     
     Optionally, also create a `state.json` file. `currently_syncing` is an optional attribute used for identifying the last object to be synced in case the job is interrupted mid-stream. The next run would begin where the last job left off.
 

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -2,6 +2,7 @@ from datetime import timedelta, datetime, timezone
 import math
 import json
 import pytz
+import urllib
 import singer
 from singer import metrics, metadata, Transformer, utils
 from singer.utils import strptime_to_utc
@@ -112,7 +113,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                   bookmark_field=None,
                   project_timezone=None,
                   days_interval=None,
-                  attribution_window=None):
+                  attribution_window=None,
+                  export_events=None):
 
     # Get endpoint_config fields
     url = endpoint_config.get('url')
@@ -235,6 +237,11 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                 querystring = '&'.join(['%s=%s' % (key, value) for (key, value) \
                     in params.items()]).replace(
                         '[parent_id]', str(parent_id))
+
+                if stream_name == 'export' and export_events:
+                    event = json.dumps([export_events] if isinstance(export_events, str) else export_events)
+                    url_encoded = urllib.parse.quote(event)
+                    querystring += f'&event={url_encoded}'
 
                 full_url = '{}/{}{}'.format(
                     url,
@@ -501,7 +508,8 @@ def sync(client, config, catalog, state, start_date):
             bookmark_field=bookmark_field,
             project_timezone=config.get('project_timezone', 'UTC'),
             days_interval=int(config.get('date_window_size', '30')),
-            attribution_window=int(config.get('attribution_window', '5'))
+            attribution_window=int(config.get('attribution_window', '5')),
+            export_events=config.get('export_events')
         )
 
         update_currently_syncing(state, None)


### PR DESCRIPTION
## Problem

Sometimes you need to filter specific events to export from the [Raw export API](https://developer.mixpanel.com/reference/export). Currently this is not possible and exporting all the events can take long time.

## Proposed changes

Add `export_events` optional parameter to export only certain events from the [Raw export API](https://developer.mixpanel.com/reference/export). The `export_events` parameter takes a list of event names:

```
"export_events": ["event_one", "event_two"]
```

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions