### PR TITLE
[AP-345] Add key properties to export stream

### DIFF
--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -21,7 +21,7 @@ STREAMS = {
         'path': 'export',
         'data_key': 'results',
         'api_method': 'GET',
-        'key_properties': [],
+        'key_properties': ['event', 'time', 'distinct_id'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['time'],
         'bookmark_query_field_from': 'from_date',


### PR DESCRIPTION
## Problem

The `export` stream doesn't include the key properties in the schema message and results duplicated events in the target. 

## Proposed changes

Add `['event', 'time', 'distinct_id']` as key_properties to the `export` stream.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions