### PR TITLE
[AP-345] Add mp_reserved_insert_id to export stream

### DIFF
--- a/tap_mixpanel/schema.py
+++ b/tap_mixpanel/schema.py
@@ -105,6 +105,13 @@ def get_schema(client, properties_flag, stream_name):
                 'type': ['null', 'string']
             }
 
+        # Add insert_id separately
+        insert_id_key = 'mp_reserved_insert_id'
+        if insert_id_key not in schema['properties']:
+            schema['properties'][insert_id_key] = {
+                'type': ['null', 'string']
+            }
+
     return schema
 
 def get_schemas(client, properties_flag):


### PR DESCRIPTION
## Problem

The `export` catalog doesn't include `mp_reserved_insert_id` , hence it's not included in the RECORD messages and not transferred to target components.

## Proposed changes

Add `mp_reserved_insert_id` to the `export` stream catalog.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions