### PR TITLE
Optional denesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ More details may be found in the [Mixpanel API Authentication](https://developer
    - `attribution_window` (integer, `5`): Latency minimum number of days to look-back to account for delays in attributing accurate results. [Default attribution window is 5 days](https://help.mixpanel.com/hc/en-us/articles/115004616486-Tracking-If-Users-Are-Offline).
    - `project_timezone` (string like `US/Pacific`): Time zone in which integer date times are stored. The project timezone may be found in the project settings in the Mixpanel console. [More info about timezones](https://help.mixpanel.com/hc/en-us/articles/115004547203-Manage-Timezones-for-Projects-in-Mixpanel). 
    - `select_properties_by_default` (`true` or `false`): Mixpanel properties are not fixed and depend on the date being uploaded. During Discovery mode and catalog.json setup, all current/existing properties will be captured. Setting this config parameter to true ensures that new properties on events and engage records are captured. Otherwise new properties will be ignored.
-   
+   - `denest_properties` (`true` or `false`): To denest large and nested JSON Mixpanel responses in the `extract` and `engage` streams. To avoid very wide schema you can disable the denesting feature and the original JSON response will be send in the RECORD message plain object. Default `denest_properties` is `true`.
+
     ```json
     {
         "api_secret": "YOUR_API_SECRET",
@@ -121,6 +122,7 @@ More details may be found in the [Mixpanel API Authentication](https://developer
         "attribution_window": "5",
         "project_timezone": "US/Pacific",
         "select_properties_by_default": "true",
+        "denest_properties": "true",
         "start_date": "2019-01-01T00:00:00Z",
         "user_agent": "tap-mixpanel <api_user_email@your_company.com>"
     }

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ More details may be found in the [Mixpanel API Authentication](https://developer
    - `attribution_window` (integer, `5`): Latency minimum number of days to look-back to account for delays in attributing accurate results. [Default attribution window is 5 days](https://help.mixpanel.com/hc/en-us/articles/115004616486-Tracking-If-Users-Are-Offline).
    - `project_timezone` (string like `US/Pacific`): Time zone in which integer date times are stored. The project timezone may be found in the project settings in the Mixpanel console. [More info about timezones](https://help.mixpanel.com/hc/en-us/articles/115004547203-Manage-Timezones-for-Projects-in-Mixpanel). 
    - `select_properties_by_default` (`true` or `false`): Mixpanel properties are not fixed and depend on the date being uploaded. During Discovery mode and catalog.json setup, all current/existing properties will be captured. Setting this config parameter to true ensures that new properties on events and engage records are captured. Otherwise new properties will be ignored.
-   - `denest_properties` (`true` or `false`): To denest large and nested JSON Mixpanel responses in the `extract` and `engage` streams. To avoid very wide schema you can disable the denesting feature and the original JSON response will be send in the RECORD message plain object. Default `denest_properties` is `true`.
+   - `denest_properties` (`true` or `false`): To denest large and nested JSON Mixpanel responses in the `extract` and `engage` streams. To avoid very wide schema you can disable the denesting feature and the original JSON response will be sent in the RECORD message as plain object. Default `denest_properties` is `true`.
 
     ```json
     {

--- a/tap_mixpanel/__init__.py
+++ b/tap_mixpanel/__init__.py
@@ -23,10 +23,10 @@ REQUIRED_CONFIG_KEYS = [
 ]
 
 
-def do_discover(client, properties_flag):
+def do_discover(client, properties_flag, denest_properties):
 
     LOGGER.info('Starting discover')
-    catalog = discover(client, properties_flag)
+    catalog = discover(client, properties_flag, denest_properties)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 
@@ -56,10 +56,11 @@ def main():
 
         config = parsed_args.config
         properties_flag = config.get('select_properties_by_default')
+        denest_properties_flag = config.get('denest_properties', 'true')
 
 
         if parsed_args.discover:
-            do_discover(client, properties_flag)
+            do_discover(client, properties_flag, denest_properties_flag)
         elif parsed_args.catalog:
             sync(client=client,
                  config=config,

--- a/tap_mixpanel/discover.py
+++ b/tap_mixpanel/discover.py
@@ -1,8 +1,8 @@
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_mixpanel.schema import get_schemas, STREAMS
 
-def discover(client, properties_flag):
-    schemas, field_metadata = get_schemas(client, properties_flag)
+def discover(client, properties_flag, denest_properties):
+    schemas, field_metadata = get_schemas(client, properties_flag, denest_properties)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():

--- a/tap_mixpanel/schema.py
+++ b/tap_mixpanel/schema.py
@@ -13,7 +13,7 @@ def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
-def get_schema(client, properties_flag, stream_name):
+def get_schema(client, properties_flag, denest_properties_flag, stream_name):
     schema_path = get_abs_path('schemas/{}.json'.format(stream_name))
 
     with open(schema_path) as file:
@@ -29,92 +29,98 @@ def get_schema(client, properties_flag, stream_name):
     else:
         schema['additionalProperties'] = False
 
-    if stream_name == 'engage':
-        properties = client.request(
-            method='GET',
-            url='https://mixpanel.com/api/2.0',
-            path='engage/properties',
-            params={'limit': 2000},
-            endpoint='engage_properties')
-        if properties.get('status') == 'ok':
-            results = properties.get('results', {})
+    # Denest properties only when it's required
+    if str(denest_properties_flag).lower() == 'true':
+        # Remove properties from the schema, we'll denest it
+        if stream_name in ['engage', 'export']:
+            schema['properties'].pop('properties', None)
+
+        if stream_name == 'engage':
+            properties = client.request(
+                method='GET',
+                url='https://mixpanel.com/api/2.0',
+                path='engage/properties',
+                params={'limit': 2000},
+                endpoint='engage_properties')
+            if properties.get('status') == 'ok':
+                results = properties.get('results', {})
+                for key, val in results.items():
+                    if key[0:1] == '$':
+                        new_key = 'mp_reserved_{}'.format(key[1:])
+                    else:
+                        new_key = key
+
+                    # Defaults
+                    this_type = ['null', 'string']
+                    this_format = None
+                    this_multiple_of = None
+                    this_additional_properties = None
+                    this_required = None
+                    this_items = False
+
+                    # property_type: string, number, boolean, datetime, object, list
+                    # Reference:
+                    # https://help.mixpanel.com/hc/en-us/articles/115004547063-Properties-Supported-Data-Types
+                    property_type = val.get('type')
+                    if property_type == 'boolean':
+                        this_type = ['null', 'boolean']
+                    elif property_type == 'number':
+                        this_type = ['null', 'number']
+                        this_multiple_of = 1e-20
+                    elif property_type == 'datetime':
+                        this_format = 'date-time'
+                    elif property_type == 'object':
+                        this_type = ['null', 'object']
+                        this_additional_properties = True
+                    elif property_type == 'list':
+                        this_type = ['null', 'array']
+                        this_required = False
+                        this_items = True
+                    schema['properties'][new_key] = {}
+                    schema['properties'][new_key]['type'] = this_type
+                    if this_format:
+                        schema['properties'][new_key]['format'] = this_format
+                    if this_multiple_of:
+                        schema['properties'][new_key]['multipleOf'] = this_multiple_of
+                    if this_additional_properties:
+                        schema['properties'][new_key]['additionalProperties'] = \
+                            this_additional_properties
+                    if this_required:
+                        schema['properties'][new_key]['required'] = this_required
+                    if this_items:
+                        schema['properties'][new_key]['items'] = {}
+
+        if stream_name == 'export':
+            # Event properties endpoint:
+            #  https://developer.mixpanel.com/docs/data-export-api#section-hr-span-style-font-family-courier-top-span
+            results = client.request(
+                method='GET',
+                url='https://mixpanel.com/api/2.0',
+                path='events/properties/top',
+                params={'limit': 2000},
+                endpoint='event_properties')
             for key, val in results.items():
                 if key[0:1] == '$':
                     new_key = 'mp_reserved_{}'.format(key[1:])
                 else:
                     new_key = key
 
-                # Defaults
-                this_type = ['null', 'string']
-                this_format = None
-                this_multiple_of = None
-                this_additional_properties = None
-                this_required = None
-                this_items = False
+                # string ONLY for event properties (no other datatypes)
+                # Reference: https://help.mixpanel.com/hc/en-us/articles/360001355266-Event-Properties#field-size-character-limits-for-event-properties
+                schema['properties'][new_key] = {
+                    'type': ['null', 'string']
+                }
 
-                # property_type: string, number, boolean, datetime, object, list
-                # Reference:
-                # https://help.mixpanel.com/hc/en-us/articles/115004547063-Properties-Supported-Data-Types
-                property_type = val.get('type')
-                if property_type == 'boolean':
-                    this_type = ['null', 'boolean']
-                elif property_type == 'number':
-                    this_type = ['null', 'number']
-                    this_multiple_of = 1e-20
-                elif property_type == 'datetime':
-                    this_format = 'date-time'
-                elif property_type == 'object':
-                    this_type = ['null', 'object']
-                    this_additional_properties = True
-                elif property_type == 'list':
-                    this_type = ['null', 'array']
-                    this_required = False
-                    this_items = True
-                schema['properties'][new_key] = {}
-                schema['properties'][new_key]['type'] = this_type
-                if this_format:
-                    schema['properties'][new_key]['format'] = this_format
-                if this_multiple_of:
-                    schema['properties'][new_key]['multipleOf'] = this_multiple_of
-                if this_additional_properties:
-                    schema['properties'][new_key]['additionalProperties'] = \
-                        this_additional_properties
-                if this_required:
-                    schema['properties'][new_key]['required'] = this_required
-                if this_items:
-                    schema['properties'][new_key]['items'] = {}
-
-    if stream_name == 'export':
-        # Event properties endpoint:
-        #  https://developer.mixpanel.com/docs/data-export-api#section-hr-span-style-font-family-courier-top-span
-        results = client.request(
-            method='GET',
-            url='https://mixpanel.com/api/2.0',
-            path='events/properties/top',
-            params={'limit': 2000},
-            endpoint='event_properties')
-        for key, val in results.items():
-            if key[0:1] == '$':
-                new_key = 'mp_reserved_{}'.format(key[1:])
-            else:
-                new_key = key
-
-            # string ONLY for event properties (no other datatypes)
-            # Reference: https://help.mixpanel.com/hc/en-us/articles/360001355266-Event-Properties#field-size-character-limits-for-event-properties
-            schema['properties'][new_key] = {
-                'type': ['null', 'string']
-            }
-
-        # Add insert_id separately
-        insert_id_key = 'mp_reserved_insert_id'
-        if insert_id_key not in schema['properties']:
-            schema['properties'][insert_id_key] = {
-                'type': ['null', 'string']
-            }
+            # Add insert_id separately
+            insert_id_key = 'mp_reserved_insert_id'
+            if insert_id_key not in schema['properties']:
+                schema['properties'][insert_id_key] = {
+                    'type': ['null', 'string']
+                }
 
     return schema
 
-def get_schemas(client, properties_flag):
+def get_schemas(client, properties_flag, denest_properties_flag):
     schemas = {}
     field_metadata = {}
 
@@ -124,7 +130,7 @@ def get_schemas(client, properties_flag):
             LOGGER.warning('Mixpanel returned a 402 indicating the Engage endpoint and stream is unavailable. Skipping.')
             continue
 
-        schema = get_schema(client, properties_flag, stream_name)
+        schema = get_schema(client, properties_flag, denest_properties_flag, stream_name)
 
         schemas[stream_name] = schema
         mdata = metadata.new()

--- a/tap_mixpanel/schemas/engage.json
+++ b/tap_mixpanel/schemas/engage.json
@@ -4,6 +4,9 @@
   "properties": {
     "distinct_id": {
       "type": ["null", "string"]
+    },
+    "properties": {
+      "type": ["null", "object"]
     }
   }
 }

--- a/tap_mixpanel/schemas/export.json
+++ b/tap_mixpanel/schemas/export.json
@@ -2,6 +2,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "mp_reserved_insert_id": {
+      "type": ["null", "string"]
+    },
     "event": {
       "type": ["null", "string"]
     },
@@ -12,24 +15,8 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "labels": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "sampling_factor": {
-      "type": ["null", "integer"]
-    },
-    "dataset": {
-      "type": ["null", "string"]
+    "properties": {
+      "type": ["null", "object"]
     }
   }
 }

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -114,7 +114,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                   project_timezone=None,
                   days_interval=None,
                   attribution_window=None,
-                  export_events=None):
+                  export_events=None,
+                  denest_properties_flag=None):
 
     # Get endpoint_config fields
     url = endpoint_config.get('url')
@@ -269,7 +270,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                         if record and str(record) != '':
                             # transform reocord and append to transformed_data array
                             transformed_record = transform_record(record, stream_name, \
-                                project_timezone)
+                                project_timezone, denest_properties_flag)
                             transformed_data.append(transformed_record)
 
                             # Check for missing keys
@@ -509,7 +510,8 @@ def sync(client, config, catalog, state, start_date):
             project_timezone=config.get('project_timezone', 'UTC'),
             days_interval=int(config.get('date_window_size', '30')),
             attribution_window=int(config.get('attribution_window', '5')),
-            export_events=config.get('export_events')
+            export_events=config.get('export_events'),
+            denest_properties_flag=config.get('denest_properties', 'true')
         )
 
         update_currently_syncing(state, None)


### PR DESCRIPTION
## Problem

The auto denesting feature of the `extract` and `engage` streams can cause very wide tables in target dwh.

## Proposed changes

Add optional `denest_properties` to `config.json`, so the user can decide to denesting or not. If value is `false` then the original JSON response will be sent in the RECORD message as plain object. Default `denest_properties` value is `true`.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- x ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions