### PR TITLE
Use insert_id as key in export stream

### DIFF
--- a/tap_mixpanel/streams.py
+++ b/tap_mixpanel/streams.py
@@ -21,7 +21,7 @@ STREAMS = {
         'path': 'export',
         'data_key': 'results',
         'api_method': 'GET',
-        'key_properties': ['event', 'time', 'distinct_id'],
+        'key_properties': ['mp_reserved_insert_id'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['time'],
         'bookmark_query_field_from': 'from_date',


### PR DESCRIPTION
## Problem

The current key properties in the `export` stream is not granular enough and loosing events if the same event fired multiple times by the same user at the same second. 

## Proposed changes

Use `$insert_id` (translated to `mp_reserved_insert_id`) as the key instead of `['event', 'time', 'distinct_id']`. `$insert_id` is a unique UUID tied to exactly one occurance of an event.

More info [here](https://developer.mixpanel.com/reference/events).

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions